### PR TITLE
[KEYCLOAK-8926] Fuse adapter: Missing runtime dependency

### DIFF
--- a/testsuite/integration-arquillian/util/src/main/java/org/keycloak/testsuite/utils/arquillian/fuse/CustomFuseContainer.java
+++ b/testsuite/integration-arquillian/util/src/main/java/org/keycloak/testsuite/utils/arquillian/fuse/CustomFuseContainer.java
@@ -106,12 +106,16 @@ public class CustomFuseContainer<T extends KarafManagedContainerConfiguration> e
             boolean fuse7 = new File(karafHomeDir, "lib/boot/").exists();
             if (fuse7) {
                 log.info("Adding karaf4 libraries to classpath.");
-                File karafLibBootDir = new File(karafHomeDir, "lib/boot/");
-                String[] libs = karafLibBootDir.list((File dir, String name) -> name.endsWith(".jar"));
-                for (String lib : libs) {
-                    String separator = classPath.length() > 0 ? File.pathSeparator : "";
-                    classPath.append(separator).append(new File(karafLibBootDir, lib));
+                String[] libDirs  = { "lib/boot/", "lib/ext/" };
+                for (String libDir : libDirs) {
+                    File karafLibBootDir = new File(karafHomeDir, libDir);
+                    String[] libs = karafLibBootDir.list((File dir, String name) -> name.endsWith(".jar"));
+                    for (String lib : libs) {
+                        String separator = classPath.length() > 0 ? File.pathSeparator : "";
+                        classPath.append(separator).append(new File(karafLibBootDir, lib));
+                    }
                 }
+
             } else { //fuse6
                 log.info("Adding karaf3 libraries to classpath.");
                 File karafLibDir = new File(karafHomeDir, "lib");


### PR DESCRIPTION
Fuse 7.x basically uses the same version as Keycloak, into other words,
`bcprov-jdk15on` version 1.60. The error reported here:
https://issues.jboss.org/browse/KEYCLOAK-8926 is related with the fact
that Bouncycastle was not being loaded during the boot time. If we look
at the logs we can find:

```
12:30:15 Red Hat Fuse starting up. Press Enter to open the shell now...
12:30:15 Unable to register security provider:
java.lang.ClassNotFoundException:
org.bouncycastle.jce.provider.BouncyCastleProvider
```

By changing `CustomFuseContainer` we will notice that the issue is
gone, because now Bouncycastle, which comes with Fuse distribution is
being added.